### PR TITLE
Make left-hand column scrollable

### DIFF
--- a/app/styles/toogles.css
+++ b/app/styles/toogles.css
@@ -117,6 +117,8 @@ h1, h2, h3, h4, h5, h6 {
   width: 25%;
   margin-top: 25px;
   padding: 0 15px;
+  height: 100%;
+  overflow-y: auto;
 }
 @media only screen and (max-width: 767px) {
   .fixed {


### PR DESCRIPTION
The left-hand column is cut off on smaller screens
