### PR TITLE
Fix whenScrolled directive for non-webkit browsers

### DIFF
--- a/app/scripts/directives/scroll.js
+++ b/app/scripts/directives/scroll.js
@@ -3,7 +3,7 @@ tooglesApp.directive('whenScrolled', function() {
     var raw = elm[0];
 
     window.onscroll = function() {
-      if (window.innerHeight + document.body.scrollTop >= document.body.offsetHeight) {
+      if (window.innerHeight + window.pageYOffset >= document.body.offsetHeight) {
         scope.$apply(attr.whenScrolled);
       }
     };


### PR DESCRIPTION
Webkit and non-Webkit engines disagree about whether the body or the documentElement scrolls. Webkit thinks the body scrolls, defining body.scrollTop and setting documentElement.scrollTop to 0. Non-Webkit browsers in standards mode think the opposite and define documentElement.scrollTop while setting body.scrollTop to 0. Sidestep this issue by using window.pageYOffset. pageYOffset is undefined in IE < 9, but those versions are not supported anyway.
