### PR TITLE
Store search modifiers as query parameters

### DIFF
--- a/app/scripts/controllers/list.js
+++ b/app/scripts/controllers/list.js
@@ -3,11 +3,11 @@
  */
 tooglesApp.controller('ListCtrl', ['$scope', '$routeParams', '$location', 'youtube', function($scope, $routeParams, $location, youtube) {
   $scope.location = $location;
-  $scope.searchsort = false;
-  $scope.searchduration = false;
-  $scope.searchtime = false;
+  $scope.searchsort = $location.search()['searchsort'] || false;
+  $scope.searchduration = $location.search()['searchduration'] || false;
+  $scope.searchtime = $location.search()['searchtime'] || false;
   $scope.section = $location.path().split('/')[1];
-  $scope.searchtype = 'videos'
+  $scope.searchtype = $location.search()['searchtype'] || 'videos';
 
   window.searchCallback = function(data) {
     if (!$scope.videos) {

--- a/app/views/search.html
+++ b/app/views/search.html
@@ -2,35 +2,35 @@
   <li>
     <a>Type</a>
     <ul>
-      <li ng-class="{active: $parent.searchtype == 'videos'}"><a ng-click="$parent.searchtype = 'videos'">Videos</a></li>
-      <li ng-class="{active: $parent.searchtype == 'playlists'}"><a ng-click="$parent.searchtype = 'playlists'">Playlists</a></li>
+      <li ng-class="{active: $parent.searchtype == 'videos'}"><a ng-click="$parent.location.search('searchtype', 'videos')">Videos</a></li>
+      <li ng-class="{active: $parent.searchtype == 'playlists'}"><a ng-click="$parent.location.search('searchtype', 'playlists')">Playlists</a></li>
     </ul>
   </li>
   <li ng-show="$parent.searchtype != 'playlists'">
     <a>Sort</a>
     <ul>
-      <li ng-class="{active: !$parent.searchsort}"><a ng-click="$parent.searchsort = false">Relevance</a></li>
-      <li ng-class="{active: $parent.searchsort == 'published'}"><a ng-click="$parent.searchsort = 'published'">Upload date</a></li>
-      <li ng-class="{active: $parent.searchsort == 'viewCount'}"><a ng-click="$parent.searchsort = 'viewCount'">View count</a></li>
-      <li ng-class="{active: $parent.searchsort == 'rating'}"><a ng-click="$parent.searchsort = 'rating'">Rating</a></li>
+      <li ng-class="{active: !$parent.searchsort}"><a ng-click="$parent.location.search('searchsort', null)">Relevance</a></li>
+      <li ng-class="{active: $parent.searchsort == 'published'}"><a ng-click="$parent.location.search('searchsort', 'published')">Upload date</a></li>
+      <li ng-class="{active: $parent.searchsort == 'viewCount'}"><a ng-click="$parent.location.search('searchsort', 'viewCount')">View count</a></li>
+      <li ng-class="{active: $parent.searchsort == 'rating'}"><a ng-click="$parent.location.search('searchsort', 'rating')">Rating</a></li>
     </ul>
   </li>
   <li ng-show="$parent.searchtype != 'playlists'">
     <a>Upload Date</a>
     <ul>
-      <li ng-class="{active: !$parent.searchtime}"><a ng-click="$parent.searchtime = false">Anytime</a></li>
-      <li ng-class="{active: $parent.searchtime == 'today'}"><a ng-click="$parent.searchtime = 'today'">Today</a></li>
-      <li ng-class="{active: $parent.searchtime == 'this_week'}"><a ng-click="$parent.searchtime = 'this_week'">This week</a></li>
-      <li ng-class="{active: $parent.searchtime == 'this_month'}"><a ng-click="$parent.searchtime = 'this_month'">This month</a></li>
+      <li ng-class="{active: !$parent.searchtime}"><a ng-click="$parent.location.search('searchtime', null)">Anytime</a></li>
+      <li ng-class="{active: $parent.searchtime == 'today'}"><a ng-click="$parent.location.search('searchtime', 'today')">Today</a></li>
+      <li ng-class="{active: $parent.searchtime == 'this_week'}"><a ng-click="$parent.location.search('searchtime', 'this_week')">This week</a></li>
+      <li ng-class="{active: $parent.searchtime == 'this_month'}"><a ng-click="$parent.location.search('searchtime',  'this_month')">This month</a></li>
     </ul>
   </li>
   <li ng-show="$parent.searchtype != 'playlists'">
     <a>Duration</a>
     <ul>
-      <li ng-class="{active: !$parent.searchduration}"><a ng-click="$parent.searchduration = false">All</a></li>
-      <li ng-class="{active: $parent.searchduration == 'short'}"><a ng-click="$parent.searchduration = 'short'">Short (&lt; 4 minutes)</a></li>
-      <li ng-class="{active: $parent.searchduration == 'medium'}"><a ng-click="$parent.searchduration = 'medium'">Medium (4-20 minutes</a></li>
-      <li ng-class="{active: $parent.searchduration == 'long'}"><a ng-click="$parent.searchduration = 'long'">Long (&gt; 20 minutes)</a></li>
+      <li ng-class="{active: !$parent.searchduration}"><a ng-click="$parent.location.search('searchduration', null)">All</a></li>
+      <li ng-class="{active: $parent.searchduration == 'short'}"><a ng-click="$parent.location.search('searchduration', 'short')">Short (&lt; 4 minutes)</a></li>
+      <li ng-class="{active: $parent.searchduration == 'medium'}"><a ng-click="$parent.location.search('searchduration', 'medium')">Medium (4-20 minutes</a></li>
+      <li ng-class="{active: $parent.searchduration == 'long'}"><a ng-click="$parent.location.search('searchduration', 'long')">Long (&gt; 20 minutes)</a></li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
This allows search modifiers to presist when navigating between viewing a video and browsing the search results, instead of resetting to the default settings.
